### PR TITLE
Handle unit with display configured as Celsius

### DIFF
--- a/custom_components/ooler/climate.py
+++ b/custom_components/ooler/climate.py
@@ -122,7 +122,11 @@ class Ooler(ClimateEntity, RestoreEntity):
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        return self._data.client.state.actual_temperature
+        actualtemp_raw = self._data.client.state.actual_temperature
+        if actualtemp_raw is not None:
+            actualtemp_fahrenheit = (9/5 * actualtemp_raw) + 32
+            return actualtemp_fahrenheit
+        return None
 
     @property
     def fan_mode(self) -> str | None:


### PR DESCRIPTION
I use my ooler in Celsius mode and everything seems to work fine except the current temperature reporting.

This change addresses it and seems to work fine, but it obviously does not work for those with units in Fahrenheit mode.
Do you know if the unit reports the temp unit in any way so we can check and apply the correct logic?
Maybe another BLE advertisement?