### PR TITLE
Add auto-reconnect with exponential backoff on startup

### DIFF
--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,0 +1,11 @@
+Fix BLE proxy crashes, connection handling, and temperature unit detection
+
+- Fix infinite loop crash when discovery_info is None in config flow - this was crashing HA for me on 2026.3.3
+- Add 30s timeout to BLE connection test to prevent HA freezes
+- Use establish_connection() instead of raw BleakClient for ESPHome proxy support
+- Guard against UnknownFlow exception when config flow is dismissed
+- Seed BLE device during setup to prevent AttributeError before callbacks fire
+- Split BLE callbacks: connectable (connect) vs passive (tracking only) - connections failing as they were trying to use my passive shelly trackers not my active ESP ones
+- Detect display temperature unit from device and convert actual_temperature accordingly - wrong temp showed in HA if device on celsius
+- Add comprehensive debug logging throughout config flow and climate entity
+

--- a/custom_components/ooler/__init__.py
+++ b/custom_components/ooler/__init__.py
@@ -7,18 +7,117 @@ from homeassistant.components.bluetooth import (
     BluetoothServiceInfoBleak,
     async_ble_device_from_address,
     async_register_callback,
-    async_track_unavailable,
 )
-from homeassistant.components.bluetooth.match import ADDRESS, BluetoothCallbackMatcher
+from homeassistant.components.bluetooth.match import ADDRESS
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
-from homeassistant.core import CoreState, Event, HomeAssistant, callback
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_STARTED,
+    EVENT_HOMEASSISTANT_STOP,
+    Platform,
+)
+from homeassistant.core import CALLBACK_TYPE, CoreState, Event, HomeAssistant, callback
+from homeassistant.helpers.event import async_call_later
 from ooler_ble_client import OolerBLEDevice
 
 from .const import _LOGGER, CONF_MODEL, DOMAIN
 from .models import OolerData
 
 PLATFORMS: list[Platform] = [Platform.CLIMATE, Platform.SENSOR, Platform.SWITCH]
+
+# Reconnect backoff intervals in seconds (30s, 1m, 2m, 5m, 10m)
+RECONNECT_BACKOFF = [30, 60, 120, 300, 600]
+RECONNECT_STARTUP_DELAY = 30  # Wait for BLE stack to initialise after HA start
+
+
+def _setup_reconnect(
+    hass: HomeAssistant,
+    address: str,
+    client: OolerBLEDevice,
+) -> tuple[CALLBACK_TYPE, CALLBACK_TYPE]:
+    """Create reconnect helpers that retry BLE connection with backoff.
+
+    Returns (cancel_reconnect, schedule_reconnect_if_needed) callbacks.
+    """
+    _reconnect_cancel: CALLBACK_TYPE | None = None
+    _reconnect_attempt: int = 0
+
+    async def _async_try_reconnect() -> None:
+        """Attempt to reconnect to the Ooler device with backoff."""
+        nonlocal _reconnect_cancel, _reconnect_attempt
+        _reconnect_cancel = None
+
+        if client.is_connected:
+            _reconnect_attempt = 0
+            return
+
+        ble_device = async_ble_device_from_address(
+            hass, address, connectable=True
+        )
+        if ble_device is None:
+            ble_device = async_ble_device_from_address(
+                hass, address, connectable=False
+            )
+
+        if ble_device is not None:
+            client.set_ble_device(ble_device)
+            try:
+                await client.connect()
+                if client.is_connected:
+                    _LOGGER.info(
+                        "Reconnected to %s after %d attempt(s)",
+                        address,
+                        _reconnect_attempt + 1,
+                    )
+                    _reconnect_attempt = 0
+                    return
+            except Exception:
+                _LOGGER.debug(
+                    "Reconnect to %s failed (attempt %d)",
+                    address,
+                    _reconnect_attempt + 1,
+                    exc_info=True,
+                )
+        else:
+            _LOGGER.debug(
+                "No BLE device found for %s (attempt %d)",
+                address,
+                _reconnect_attempt + 1,
+            )
+
+        # Schedule next retry with capped exponential backoff
+        _reconnect_attempt += 1
+        delay = RECONNECT_BACKOFF[
+            min(_reconnect_attempt - 1, len(RECONNECT_BACKOFF) - 1)
+        ]
+        _LOGGER.debug(
+            "Will retry %s in %ds (attempt %d)", address, delay, _reconnect_attempt
+        )
+        _reconnect_cancel = async_call_later(
+            hass,
+            delay,
+            lambda _now: hass.async_create_task(_async_try_reconnect()),
+        )
+
+    @callback
+    def cancel_reconnect() -> None:
+        """Cancel any pending reconnect timer."""
+        nonlocal _reconnect_cancel
+        if _reconnect_cancel is not None:
+            _reconnect_cancel()
+            _reconnect_cancel = None
+
+    @callback
+    def schedule_reconnect_if_needed() -> None:
+        """Start the reconnect loop if the client is not connected."""
+        nonlocal _reconnect_cancel
+        if not client.is_connected and _reconnect_cancel is None:
+            _reconnect_cancel = async_call_later(
+                hass,
+                RECONNECT_STARTUP_DELAY,
+                lambda _now: hass.async_create_task(_async_try_reconnect()),
+            )
+
+    return cancel_reconnect, schedule_reconnect_if_needed
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -38,6 +137,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         client.set_ble_device(ble_device)
 
     @callback
+    def _async_update_ble_passive(
+        service_info: BluetoothServiceInfoBleak,
+        change: BluetoothChange,
+    ) -> None:
+        """Update BLE device reference from passive sources (e.g. Shelly).
+
+        Only updates the device reference for tracking; does NOT attempt
+        to connect since passive sources can't relay BLE connections.
+        """
+        if not hasattr(client, "_ble_device"):
+            _LOGGER.debug(
+                "Passive BLE update seeding device for %s from %s",
+                service_info.address,
+                service_info.source,
+            )
+            client.set_ble_device(service_info.device)
+
+    cancel_reconnect, schedule_reconnect_if_needed = _setup_reconnect(
+        hass, address, client
+    )
+
+    @callback
     def _async_update_ble_connectable(
         service_info: BluetoothServiceInfoBleak,
         change: BluetoothChange,
@@ -48,26 +169,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             service_info.address,
             service_info.source,
         )
+        cancel_reconnect()  # BLE stack found us — no need for timer
         client.set_ble_device(service_info.device)
         hass.async_create_task(client.connect())
-
-    @callback
-    def _async_update_ble_passive(
-        service_info: BluetoothServiceInfoBleak,
-        change: BluetoothChange,
-    ) -> None:
-        """Update BLE device reference from passive sources (e.g. Shelly).
-
-        Only updates the device reference for tracking; does NOT attempt
-        to connect since passive sources can't relay BLE connections.
-        """
-        if not hasattr(client, '_ble_device'):
-            _LOGGER.debug(
-                "Passive BLE update seeding device for %s from %s",
-                service_info.address,
-                service_info.source,
-            )
-            client.set_ble_device(service_info.device)
 
     # Register for connectable callbacks — these trigger connection
     entry.async_on_unload(
@@ -90,14 +194,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
     )
 
-    # def _unavailable_callback(info: BluetoothServiceInfoBleak) -> None:
-    #     _LOGGER.error("%s is no longer seen", info.address)
-    #     hass.async_create_task(client.connect())
-
-    # entry.async_on_unload(
-    #     async_track_unavailable(hass, _unavailable_callback, address, connectable=True)
-    # )
-
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = OolerData(
         address,
         model,
@@ -106,13 +202,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    # After HA is fully started, kick off reconnect if BLE callbacks haven't
+    # already connected us.
+    if hass.state is CoreState.running:
+        schedule_reconnect_if_needed()
+    else:
+        entry.async_on_unload(
+            hass.bus.async_listen_once(
+                EVENT_HOMEASSISTANT_STARTED,
+                lambda _event: schedule_reconnect_if_needed(),
+            )
+        )
+
     async def _async_stop(event: Event) -> None:
         """Close the connection."""
+        cancel_reconnect()
         await client.stop()
 
     entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_stop)
     )
+    entry.async_on_unload(cancel_reconnect)
     return True
 
 

--- a/custom_components/ooler/__init__.py
+++ b/custom_components/ooler/__init__.py
@@ -1,20 +1,21 @@
 """The Ooler Sleep System integration."""
-
 from __future__ import annotations
 
 from homeassistant.components.bluetooth import (
     BluetoothChange,
     BluetoothScanningMode,
     BluetoothServiceInfoBleak,
+    async_ble_device_from_address,
     async_register_callback,
+    async_track_unavailable,
 )
-from homeassistant.components.bluetooth.match import ADDRESS
+from homeassistant.components.bluetooth.match import ADDRESS, BluetoothCallbackMatcher
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import CoreState, Event, HomeAssistant, callback
 from ooler_ble_client import OolerBLEDevice
 
-from .const import CONF_MODEL, DOMAIN
+from .const import _LOGGER, CONF_MODEL, DOMAIN
 from .models import OolerData
 
 PLATFORMS: list[Platform] = [Platform.CLIMATE, Platform.SENSOR, Platform.SWITCH]
@@ -28,23 +29,74 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     model = entry.data[CONF_MODEL]
     client = OolerBLEDevice(model=model)
 
+    # Seed the BLE device immediately so it's available before callbacks fire
+    ble_device = async_ble_device_from_address(hass, address, connectable=True)
+    if ble_device is None:
+        ble_device = async_ble_device_from_address(hass, address, connectable=False)
+    if ble_device is not None:
+        _LOGGER.debug("Seeding BLE device for %s from %s", address, ble_device.name)
+        client.set_ble_device(ble_device)
+
     @callback
-    def _async_update_ble(
+    def _async_update_ble_connectable(
         service_info: BluetoothServiceInfoBleak,
         change: BluetoothChange,
     ) -> None:
-        """Update from a ble callback."""
+        """Update from a connectable BLE source and connect."""
+        _LOGGER.debug(
+            "Connectable BLE update for %s from %s",
+            service_info.address,
+            service_info.source,
+        )
         client.set_ble_device(service_info.device)
         hass.async_create_task(client.connect())
 
+    @callback
+    def _async_update_ble_passive(
+        service_info: BluetoothServiceInfoBleak,
+        change: BluetoothChange,
+    ) -> None:
+        """Update BLE device reference from passive sources (e.g. Shelly).
+
+        Only updates the device reference for tracking; does NOT attempt
+        to connect since passive sources can't relay BLE connections.
+        """
+        if not hasattr(client, '_ble_device'):
+            _LOGGER.debug(
+                "Passive BLE update seeding device for %s from %s",
+                service_info.address,
+                service_info.source,
+            )
+            client.set_ble_device(service_info.device)
+
+    # Register for connectable callbacks — these trigger connection
     entry.async_on_unload(
         async_register_callback(
             hass,
-            _async_update_ble,
+            _async_update_ble_connectable,
             {ADDRESS: address},
             BluetoothScanningMode.ACTIVE,
         )
     )
+
+    # Register for passive callbacks — only seeds the device reference
+    # so that _ble_device exists even when only Shelly proxies see the device
+    entry.async_on_unload(
+        async_register_callback(
+            hass,
+            _async_update_ble_passive,
+            {ADDRESS: address},
+            BluetoothScanningMode.PASSIVE,
+        )
+    )
+
+    # def _unavailable_callback(info: BluetoothServiceInfoBleak) -> None:
+    #     _LOGGER.error("%s is no longer seen", info.address)
+    #     hass.async_create_task(client.connect())
+
+    # entry.async_on_unload(
+    #     async_track_unavailable(hass, _unavailable_callback, address, connectable=True)
+    # )
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = OolerData(
         address,

--- a/custom_components/ooler/climate.py
+++ b/custom_components/ooler/climate.py
@@ -1,5 +1,4 @@
 """Support for Ooler Sleep System controls."""
-
 from __future__ import annotations
 
 from asyncio import sleep
@@ -19,8 +18,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers import entity_platform
+from homeassistant.helpers import device_registry as dr, entity_platform
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -57,6 +55,12 @@ async def async_setup_entry(
     )
 
 
+# Ooler firmware quirk: set_temperature is always in °F, but actual_temperature
+# is reported in the device's display unit (°C or °F). We declare FAHRENHEIT as
+# our native unit and convert actual_temperature to °F when the device is in °C mode.
+DISPLAY_TEMPERATURE_UNIT_CHAR = "2c988613-fe15-4067-85bc-8e59d5e0b1e3"
+
+
 class Ooler(ClimateEntity, RestoreEntity):
     """Representation of Ooler Thermostat."""
 
@@ -66,6 +70,7 @@ class Ooler(ClimateEntity, RestoreEntity):
     _attr_target_temperature_step = 1
     _attr_min_temp = DEFAULT_MIN_TEMP
     _attr_max_temp = DEFAULT_MAX_TEMP
+    _device_reports_celsius: bool | None = None  # Detected from device
 
     _attr_supported_features = (
         ClimateEntityFeature.TARGET_TEMPERATURE
@@ -123,8 +128,18 @@ class Ooler(ClimateEntity, RestoreEntity):
 
     @property
     def current_temperature(self) -> float | None:
-        """Return the current temperature."""
-        return self._data.client.state.actual_temperature
+        """Return the current temperature.
+
+        The Ooler firmware always sends set_temperature in °F, but
+        actual_temperature uses the device's display unit. We detect
+        this and convert to °F if needed.
+        """
+        actual = self._data.client.state.actual_temperature
+        if actual is None:
+            return None
+        if self._device_reports_celsius:
+            return actual * 9 / 5 + 32
+        return actual
 
     @property
     def fan_mode(self) -> str | None:
@@ -176,6 +191,9 @@ class Ooler(ClimateEntity, RestoreEntity):
     @callback
     def _handle_state_update(self, *args: Any) -> None:
         """Handle state update."""
+        if self._device_reports_celsius is None:
+            # Try to detect the display unit on first state update
+            self.hass.async_create_task(self._async_detect_temperature_unit())
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:
@@ -185,6 +203,26 @@ class Ooler(ClimateEntity, RestoreEntity):
             self._data.client.register_callback(self._handle_state_update)
         )
 
+    async def _async_detect_temperature_unit(self) -> None:
+        """Read the display temperature unit characteristic from the device."""
+        client = self._data.client
+        if client._client is None or not client._client.is_connected:
+            return
+        try:
+            unit_byte = await client._client.read_gatt_char(
+                DISPLAY_TEMPERATURE_UNIT_CHAR
+            )
+            # 0 = Fahrenheit, 1 = Celsius (based on Ooler BLE protocol)
+            unit_val = int.from_bytes(unit_byte, "little")
+            self._device_reports_celsius = unit_val == 1
+            _LOGGER.debug(
+                "Ooler display unit detected: %s (raw=%s)",
+                "Celsius" if self._device_reports_celsius else "Fahrenheit",
+                unit_val,
+            )
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.debug("Could not read display temperature unit: %s", err)
+
     # async def async_update(self) -> None:
     #     """Grab the state from device and update HA."""
     #     await self._data.client.async_poll()
@@ -192,7 +230,10 @@ class Ooler(ClimateEntity, RestoreEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new HVACMode (On/Off)."""
-        power = hvac_mode != HVACMode.OFF
+        if hvac_mode == HVACMode.OFF:
+            power = False
+        else:
+            power = True
         client = self._data.client
         if not client.is_connected:
             _LOGGER.debug("Client not connected. Attempting to connect")
@@ -203,10 +244,7 @@ class Ooler(ClimateEntity, RestoreEntity):
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set the fan mode. Valid values are Silent, Regular, and Boost."""
         if fan_mode not in self._fan_modes:
-            error = (
-                "Invalid fan_mode value: "
-                "Valid values are 'Silent', 'Regular', and 'Boost'"
-            )
+            error = "Invalid fan_mode value: Valid values are 'Silent', 'Regular', and 'Boost'"
             _LOGGER.error(error)
             return
         client = self._data.client
@@ -239,9 +277,7 @@ class Ooler(ClimateEntity, RestoreEntity):
         await client.set_clean(True)
         _LOGGER.debug("Cleaning the device: %s", self.name)
 
-    # This service function is necessary because the Bluetooth connection is active,
-    # which means when Hass is connected to Ooler, nothing else can connect to Ooler
-    # including the phone app.
+    # This service function is necessary because the Bluetooth connection is active, which means when Hass is connected to Ooler, nothing else can connect to Ooler including the phone app.
     async def async_pause_client(self, sec_delay: int = 60) -> None:
         """Disconnect Hass from the device."""
         await self._data.client.stop()

--- a/custom_components/ooler/config_flow.py
+++ b/custom_components/ooler/config_flow.py
@@ -1,23 +1,30 @@
 """Config flow for Ooler Sleep System integration."""
-
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
 
-import voluptuous as vol
+from bleak import BleakClient
 from bleak.backends.device import BLEDevice
+from bleak_retry_connector import establish_connection
+from ooler_ble_client import OolerBLEDevice
+from ooler_ble_client.const import POWER_CHAR
+import voluptuous as vol
+
 from homeassistant.components.bluetooth import (
     BluetoothServiceInfoBleak,
+    async_ble_device_from_address,
     async_discovered_service_info,
     async_last_service_info,
 )
 from homeassistant.config_entries import ConfigFlow
-from homeassistant.const import CONF_ADDRESS  # , CONF_TOKEN
+from homeassistant.const import CONF_ADDRESS
 from homeassistant.data_entry_flow import FlowResult
-from ooler_ble_client import OolerBLEDevice, test_connection
 
-from .const import CONF_MODEL, DOMAIN  # , _LOGGER
+from .const import CONF_MODEL, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class OolerConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -38,6 +45,13 @@ class OolerConfigFlow(ConfigFlow, domain=DOMAIN):
         self, discovery_info: BluetoothServiceInfoBleak
     ) -> FlowResult:
         """Handle the bluetooth discovery step."""
+        _LOGGER.debug(
+            "async_step_bluetooth: name=%s address=%s connectable=%s source=%s",
+            discovery_info.name,
+            discovery_info.address,
+            discovery_info.connectable,
+            discovery_info.source,
+        )
         await self.async_set_unique_id(discovery_info.address)
         self._abort_if_unique_id_configured()
         if not discovery_info.name.startswith("OOLER"):
@@ -54,6 +68,7 @@ class OolerConfigFlow(ConfigFlow, domain=DOMAIN):
 
         model_name = discovery_info.name
         assert model_name is not None
+        _LOGGER.debug("async_step_bluetooth_confirm: model=%s user_input=%s", model_name, user_input)
 
         if user_input is not None:
             if not self._paired:
@@ -73,20 +88,46 @@ class OolerConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the user step to pick discovered device."""
         if user_input is not None:
             address = user_input[CONF_ADDRESS]
+            _LOGGER.debug("async_step_user: selected address=%s", address)
 
             await self.async_set_unique_id(address, raise_on_progress=False)
             self._abort_if_unique_id_configured()
 
             model_name = self._discovered_devices[address]
             if model_name is None:
+                _LOGGER.debug("async_step_user: model_name is None, aborting")
                 return self.async_abort(reason="no_devices_found")
 
             discovery_info = async_last_service_info(
                 self.hass, address, connectable=True
             )
+            _LOGGER.debug(
+                "async_step_user: async_last_service_info(connectable=True) = %s",
+                discovery_info,
+            )
+            if discovery_info is None:
+                discovery_info = async_last_service_info(
+                    self.hass, address, connectable=False
+                )
+                _LOGGER.debug(
+                    "async_step_user: async_last_service_info(connectable=False) = %s",
+                    discovery_info,
+                )
+            if discovery_info is None:
+                _LOGGER.debug("async_step_user: no service info at all, aborting")
+                return self.async_abort(reason="no_devices_found")
+
+            _LOGGER.debug(
+                "async_step_user: using discovery name=%s address=%s connectable=%s source=%s",
+                discovery_info.name,
+                discovery_info.address,
+                discovery_info.connectable,
+                discovery_info.source,
+            )
             self._discovery_info = discovery_info
 
             if not self._paired:
+                _LOGGER.debug("async_step_user: not paired, entering wait_for_pairing_mode")
                 return await self.async_step_wait_for_pairing_mode()
             return self._create_ooler_entry(model_name)
 
@@ -99,9 +140,17 @@ class OolerConfigFlow(ConfigFlow, domain=DOMAIN):
                 or not discovery_info.name.startswith("OOLER")
             ):
                 continue
+            _LOGGER.debug(
+                "async_step_user: discovered %s at %s (connectable=%s, source=%s)",
+                discovery_info.name,
+                address,
+                discovery_info.connectable,
+                discovery_info.source,
+            )
             self._discovered_devices[address] = discovery_info.name
 
         if not self._discovered_devices:
+            _LOGGER.debug("async_step_user: no OOLER devices discovered")
             return self.async_abort(reason="no_devices_found")
 
         return self.async_show_form(
@@ -115,11 +164,22 @@ class OolerConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Wait for device to enter pairing mode."""
+        _LOGGER.debug(
+            "wait_for_pairing: _pairing_task=%s has_discovery_info=%s",
+            self._pairing_task,
+            self._discovery_info is not None,
+        )
         if not self._pairing_task:
             discovery_info = self._discovery_info
             if discovery_info is None:
+                _LOGGER.debug("wait_for_pairing: discovery_info is None, showing timeout")
                 return self.async_show_progress_done(next_step_id="pairing_timeout")
             bledevice = discovery_info.device
+            _LOGGER.debug(
+                "wait_for_pairing: creating connection test task for %s (%s)",
+                bledevice.name,
+                bledevice.address,
+            )
             self._pairing_task = self.hass.async_create_task(
                 self._async_check_ooler_connection(bledevice)
             )
@@ -127,11 +187,14 @@ class OolerConfigFlow(ConfigFlow, domain=DOMAIN):
                 step_id="wait_for_pairing_mode",
                 progress_action="wait_for_pairing_mode",
             )
+        _LOGGER.debug("wait_for_pairing: awaiting existing pairing task")
         try:
             await self._pairing_task
         except asyncio.CancelledError:
+            _LOGGER.debug("wait_for_pairing: task was CANCELLED (connection test failed)")
             self._pairing_task = None
             return self.async_show_progress_done(next_step_id="pairing_timeout")
+        _LOGGER.debug("wait_for_pairing: task completed SUCCESSFULLY")
         self._pairing_task = None
         return self.async_show_progress_done(next_step_id="pairing_complete")
 
@@ -141,6 +204,7 @@ class OolerConfigFlow(ConfigFlow, domain=DOMAIN):
         """Create a configuration entry for a device that entered pairing mode."""
         assert self._discovery_info
         model_name = self._discovery_info.name
+        _LOGGER.debug("pairing_complete: creating entry for %s", model_name)
 
         await self.async_set_unique_id(
             self._discovery_info.address, raise_on_progress=False
@@ -153,6 +217,7 @@ class OolerConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Inform the user that the device never entered pairing mode."""
+        _LOGGER.debug("pairing_timeout: user_input=%s", user_input)
         if user_input is not None:
             return await self.async_step_wait_for_pairing_mode()
 
@@ -162,55 +227,113 @@ class OolerConfigFlow(ConfigFlow, domain=DOMAIN):
     def _create_ooler_entry(self, model_name: str) -> FlowResult:
         return self.async_create_entry(
             title=model_name,
-            data={CONF_MODEL: model_name},  # could require discovery_info.name instead
+            data={CONF_MODEL: model_name},
         )
 
-    # async def _async_wait_for_pairing_mode(self) -> None:
-    #     """Process advertisements until pairing mode is detected."""
-    #     in_pairing_mode: Future[bool] = Future()
-
-    #     async def device_in_pairing_mode(
-    #         device: BLEDevice,
-    #         advertisement_data: AdvertisementData,
-    #     ):
-    #         assert self._discovery_info is not None
-    #         if device.address == self._discovery_info.address:
-    #             in_pairing_mode.set_result(True)
-
-    #     pairing_scanner = BleakScanner(
-    #         device_in_pairing_mode,
-    #         scanning_mode="passive",
-    #         bluez=BlueZScannerArgs(
-    #             or_patterns=[OrPattern(0, AdvertisementDataType.FLAGS, b"\x02")]
-    #         ),
-    #     )
-
-    #     try:
-    #         _LOGGER.error("Starting Ooler scanner")
-    #         result = await pairing_scanner.start()
-    #         _LOGGER.error("Result of scanner start is: %s", result)
-    #         await asyncio.sleep(ADDITIONAL_DISCOVERY_TIMEOUT)
-    #         # _LOGGER.error("Scanner: ", pairing_scanner)
-    #         _LOGGER.error("Stopping Ooler scanner")
-    #         await pairing_scanner.stop()
-    #         raise asyncio.TimeoutError
-
-    #     finally:
-    #         self.hass.async_create_task(
-    #             self.hass.config_entries.flow.async_configure(flow_id=self.flow_id)
-    #         )
-
     async def _async_check_ooler_connection(self, bledevice: BLEDevice) -> None:
-        """Try to connect to client and test read and write power functions."""
+        """Try to connect and test read/write to verify device is paired."""
+        _LOGGER.debug(
+            "_async_check: starting, will sleep 5s then test %s (%s)",
+            bledevice.name,
+            bledevice.address,
+        )
         await asyncio.sleep(5)
         assert self._pairing_task is not None
         try:
-            await test_connection(bledevice)
-        except Exception:  # pylint: disable=broad-except
+            _LOGGER.debug("_async_check: calling _test_connection_via_proxy (timeout=30s)")
+            await asyncio.wait_for(
+                self._test_connection_via_proxy(bledevice), timeout=30
+            )
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.debug(
+                "_async_check: connection test FAILED: %s: %s",
+                type(err).__name__,
+                err,
+            )
             self._pairing_task.cancel()
         else:
+            _LOGGER.debug("_async_check: connection test PASSED, device is paired")
             self._paired = True
         finally:
-            self.hass.async_create_task(
-                self.hass.config_entries.flow.async_configure(flow_id=self.flow_id)
+            _LOGGER.debug("_async_check: reconfiguring flow")
+            try:
+                self.hass.async_create_task(
+                    self.hass.config_entries.flow.async_configure(
+                        flow_id=self.flow_id
+                    )
+                )
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.debug("_async_check: flow already dismissed, ignoring")
+
+    async def _test_connection_via_proxy(self, bledevice: BLEDevice) -> bool:
+        """Test connection using establish_connection for reliable proxy support."""
+        # Try to get a connectable BLEDevice from a proxy that supports active connections
+        connectable_device = async_ble_device_from_address(
+            self.hass, bledevice.address, connectable=True
+        )
+        if connectable_device:
+            _LOGGER.debug(
+                "_test_conn: got connectable BLEDevice from proxy for %s (%s)",
+                connectable_device.name,
+                connectable_device.address,
             )
+            target = connectable_device
+        else:
+            _LOGGER.debug(
+                "_test_conn: no connectable proxy found, falling back to %s (%s)",
+                bledevice.name,
+                bledevice.address,
+            )
+            target = bledevice
+
+        _LOGGER.debug("_test_conn: establishing connection")
+        client = await establish_connection(
+            BleakClient,
+            target,
+            target.name or target.address,
+        )
+        _LOGGER.debug("_test_conn: connected, is_connected=%s", client.is_connected)
+        try:
+            _LOGGER.debug("_test_conn: reading POWER_CHAR (%s)", POWER_CHAR)
+            orig_power_byte = await client.read_gatt_char(POWER_CHAR)
+            orig_power = bool(int.from_bytes(orig_power_byte, "little"))
+            _LOGGER.debug(
+                "_test_conn: current power=%s (raw=%s)", orig_power, orig_power_byte.hex()
+            )
+
+            write_power_byte = int(not orig_power).to_bytes(1, "little")
+            _LOGGER.debug(
+                "_test_conn: writing power=%s (raw=%s)",
+                not orig_power,
+                write_power_byte.hex(),
+            )
+            await client.write_gatt_char(POWER_CHAR, write_power_byte, True)
+            _LOGGER.debug("_test_conn: write OK, sleeping 1s before verify")
+
+            await asyncio.sleep(1)
+
+            read_power_byte = await client.read_gatt_char(POWER_CHAR)
+            _LOGGER.debug(
+                "_test_conn: verify read=%s (expected=%s)",
+                read_power_byte.hex(),
+                write_power_byte.hex(),
+            )
+
+            if write_power_byte == read_power_byte:
+                _LOGGER.debug("_test_conn: VERIFIED OK - restoring original power state")
+                await client.write_gatt_char(POWER_CHAR, orig_power_byte, True)
+                _LOGGER.debug("_test_conn: SUCCESS - pairing confirmed")
+                return True
+            else:
+                _LOGGER.debug(
+                    "_test_conn: VERIFY FAILED - wrote %s but read %s",
+                    write_power_byte.hex(),
+                    read_power_byte.hex(),
+                )
+                raise RuntimeError(
+                    f"Power write-back verification failed: wrote {write_power_byte.hex()}, "
+                    f"read {read_power_byte.hex()}"
+                )
+        finally:
+            _LOGGER.debug("_test_conn: disconnecting")
+            await client.disconnect()


### PR DESCRIPTION
## Problem

After an HA restart, Ooler devices often become permanently **unavailable**. The integration relies entirely on passive BLE discovery callbacks to establish the initial connection. If the Ooler isn't detected during the initial Bluetooth scan window (device in deep sleep, BLE adapter not yet ready, etc.), entities remain unavailable indefinitely with no retry mechanism.

The only workaround is to manually disable/re-enable the config entry or restart HA again.

## Fix

Adds a `_setup_reconnect()` helper that creates a reconnect loop with capped exponential backoff:

- **After HA startup**: waits 30s for the BLE stack to fully initialise, then checks if the client is connected
- **Retry schedule**: 30s, 60s, 2m, 5m, 10m (capped) — keeps retrying until the device is found
- **BLE callback integration**: if the BLE scanner finds the device naturally, the retry timer is cancelled immediately (no wasted attempts)
- **Config entry reload**: also triggers reconnect if the entry is reloaded while HA is already running
- **Cleanup**: timers are cancelled on entry unload and HA stop

The reconnect logic is extracted into a standalone function to keep `async_setup_entry` manageable.

## Testing

Tested on a live HA instance (2026.3.3) with two Ooler devices. After an HA restart where both devices went unavailable, the reconnect mechanism successfully recovered both devices without manual intervention.

Co-Authored-By: Oz <oz-agent@warp.dev>