### PR TITLE
Fix saved schedule dropdown identification

### DIFF
--- a/custom_components/ooler/coordinator.py
+++ b/custom_components/ooler/coordinator.py
@@ -272,7 +272,11 @@ class OolerCoordinator:
             schedule = await self.client.read_sleep_schedule()
             if schedule.nights:
                 self._cached_sleep_schedule = schedule
-            self._validate_active_saved_name(schedule)
+            # Validate against device schedule if active, else cached schedule
+            validate_against = (
+                schedule if schedule.nights else self._cached_sleep_schedule or schedule
+            )
+            self._validate_active_saved_name(validate_against)
         except (BleakError, TimeoutError):
             _LOGGER.debug(
                 "Failed to read sleep schedule from Ooler %s",
@@ -417,6 +421,7 @@ class OolerCoordinator:
             )
         await self.async_ensure_connected()
         await self.client.set_sleep_schedule(self._cached_sleep_schedule.nights)
+        self._validate_active_saved_name(self._cached_sleep_schedule)
         self._async_notify_listeners()
 
     async def async_disable_sleep_schedule(self) -> None:
@@ -425,7 +430,10 @@ class OolerCoordinator:
             self._cached_sleep_schedule = self.client.sleep_schedule
         await self.async_ensure_connected()
         await self.client.clear_sleep_schedule()
+        # Identify saved name from cache so dropdown shows what will re-enable
         self._active_saved_name = None
+        if self._cached_sleep_schedule is not None:
+            self._validate_active_saved_name(self._cached_sleep_schedule)
         self._async_notify_listeners()
 
     async def async_write_sleep_schedule(
@@ -436,6 +444,8 @@ class OolerCoordinator:
         await self.client.set_sleep_schedule(nights)
         self._cached_sleep_schedule = self.client.sleep_schedule
         self._active_saved_name = None
+        if self._cached_sleep_schedule is not None:
+            self._validate_active_saved_name(self._cached_sleep_schedule)
         self._async_notify_listeners()
 
     # --- Schedule storage ---
@@ -451,12 +461,21 @@ class OolerCoordinator:
         return self._active_saved_name
 
     def _validate_active_saved_name(self, schedule: OolerSleepSchedule) -> None:
-        """Clear active_saved_name if the device schedule no longer matches."""
-        if self._active_saved_name is None:
+        """Clear active_saved_name if stale, or identify it from saved schedules."""
+        if self._active_saved_name is not None:
+            saved = self._saved_schedules.get(self._active_saved_name)
+            if saved is None or saved.nights != schedule.nights:
+                self._active_saved_name = None
+            else:
+                return
+        # Try to identify which saved schedule matches the device schedule
+        if not schedule.nights:
             return
-        saved = self._saved_schedules.get(self._active_saved_name)
-        if saved is None or saved.nights != schedule.nights:
-            self._active_saved_name = None
+        for name, saved in self._saved_schedules.items():
+            if saved.nights == schedule.nights:
+                self._active_saved_name = name
+                return
+                return
 
     @property
     def tonight_schedule(self) -> SleepScheduleNight | None:

--- a/custom_components/ooler/manifest.json
+++ b/custom_components/ooler/manifest.json
@@ -21,5 +21,5 @@
   "requirements": [
     "ooler_ble_client==1.0.0"
   ],
-  "version": "2026.4.0"
+  "version": "2026.4.1"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "name": "Ooler",
+  "render_readme": true,
   "hacs": "2.0.5",
   "homeassistant": "2026.3.0"
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1131,6 +1131,71 @@ async def test_coordinator_active_saved_name_property() -> None:
     assert coordinator.active_saved_name == "test"
 
 
+async def test_coordinator_enable_identifies_saved_name() -> None:
+    """Test enabling schedule identifies matching saved schedule name."""
+    coordinator, _client = make_coordinator()
+    schedule = make_mock_schedule()
+    coordinator._cached_sleep_schedule = schedule
+    coordinator._saved_schedules = {"weekday": schedule}
+
+    await coordinator.async_enable_sleep_schedule()
+
+    assert coordinator._active_saved_name == "weekday"
+
+
+async def test_coordinator_disable_keeps_saved_name_from_cache() -> None:
+    """Test disabling schedule identifies saved name from cached schedule."""
+    coordinator, client = make_coordinator()
+    schedule = make_mock_schedule()
+    client.sleep_schedule = schedule
+    coordinator._saved_schedules = {"weekday": schedule}
+    coordinator._active_saved_name = "weekday"
+
+    await coordinator.async_disable_sleep_schedule()
+
+    assert coordinator._active_saved_name == "weekday"
+
+
+async def test_coordinator_write_schedule_identifies_saved_name() -> None:
+    """Test writing a schedule that matches a saved one sets active name."""
+    coordinator, client = make_coordinator()
+    schedule = make_mock_schedule()
+    coordinator._saved_schedules = {"weekday": schedule}
+    client.sleep_schedule = schedule
+
+    await coordinator.async_write_sleep_schedule(schedule.nights)
+
+    assert coordinator._active_saved_name == "weekday"
+
+
+async def test_coordinator_post_connect_identifies_saved_name() -> None:
+    """Test post-connect identifies saved schedule name when none is set."""
+    coordinator, client = make_coordinator()
+    schedule = make_mock_schedule()
+    client.read_sleep_schedule = AsyncMock(return_value=schedule)
+    coordinator._saved_schedules = {"weekday": schedule}
+
+    await coordinator._async_post_connect()
+
+    assert coordinator._active_saved_name == "weekday"
+
+
+async def test_coordinator_post_connect_preserves_saved_name_from_cache() -> None:
+    """Test post-connect keeps saved name when device is empty but cache matches."""
+    coordinator, client = make_coordinator()
+    schedule = make_mock_schedule()
+    empty_schedule = MagicMock()
+    empty_schedule.nights = []
+    client.read_sleep_schedule = AsyncMock(return_value=empty_schedule)
+    coordinator._cached_sleep_schedule = schedule
+    coordinator._saved_schedules = {"weekday": schedule}
+    coordinator._active_saved_name = "weekday"
+
+    await coordinator._async_post_connect()
+
+    assert coordinator._active_saved_name == "weekday"
+
+
 async def test_coordinator_async_start_loads_store(
     hass: HomeAssistant,
 ) -> None:


### PR DESCRIPTION
## Summary

- Fix saved schedule select entity not reflecting the active schedule name after toggle off/on, bluetooth reconnect, or when a matching schedule is set externally
- The core issue was `_validate_active_saved_name` returning early without searching saved schedules when the current name was cleared as stale
- Also validates against the cached schedule when the device schedule is empty (paused), so the dropdown shows what will re-enable
- Add `render_readme` to `hacs.json` so HACS displays repository information

## Test plan

- [x] 247 tests pass, 100% coverage
- [x] `ruff check` and `ruff format` clean
- [x] Tested on device via `2026.4.1b1` pre-release:
  - Load saved schedule → name shows
  - Toggle schedule off → name persists
  - Toggle schedule on → name recovers
  - Toggle bluetooth off/on with active schedule → name recovers
  - Toggle bluetooth off/on with paused schedule → name persists
  - External schedule matching a saved name → identified on reconnect